### PR TITLE
Create Endpoint to find all categories

### DIFF
--- a/src/app.module.ts
+++ b/src/app.module.ts
@@ -3,12 +3,14 @@ import { ProductsModule } from './models/products/products.module';
 import { MongooseModule } from '@nestjs/mongoose';
 import * as process from 'process';
 import { ConfigModule } from '@nestjs/config';
+import { CategoriesModule } from './models/categories/categories.module';
 
 @Module({
   imports: [
     ConfigModule.forRoot(),
     ProductsModule,
     MongooseModule.forRoot(process.env.MONGO_URI),
+    CategoriesModule,
   ],
 })
 export class AppModule {}

--- a/src/models/categories/categories.controller.ts
+++ b/src/models/categories/categories.controller.ts
@@ -1,0 +1,12 @@
+import { Controller, Get } from '@nestjs/common';
+import { CategoriesService } from './categories.service';
+import { ICategory } from './interfaces/categories.interfaces';
+
+@Controller('categories')
+export class CategoriesController {
+  constructor(private categoriesService: CategoriesService) {}
+  @Get('/')
+  async getAllCategories(): Promise<ICategory> {
+    return this.categoriesService.findAllCategories();
+  }
+}

--- a/src/models/categories/categories.controller.ts
+++ b/src/models/categories/categories.controller.ts
@@ -6,7 +6,7 @@ import { ICategory } from './interfaces/categories.interfaces';
 export class CategoriesController {
   constructor(private categoriesService: CategoriesService) {}
   @Get('/')
-  async getAllCategories(): Promise<ICategory> {
+  async getAllCategories(): Promise<ICategory[]> {
     return this.categoriesService.findAllCategories();
   }
 }

--- a/src/models/categories/categories.module.ts
+++ b/src/models/categories/categories.module.ts
@@ -1,0 +1,9 @@
+import { Module } from '@nestjs/common';
+import { CategoriesService } from './categories.service';
+import { CategoriesController } from './categories.controller';
+
+@Module({
+  providers: [CategoriesService],
+  controllers: [CategoriesController]
+})
+export class CategoriesModule {}

--- a/src/models/categories/categories.module.ts
+++ b/src/models/categories/categories.module.ts
@@ -6,9 +6,7 @@ import { CategorySchema } from './entities/category.entities';
 
 @Module({
   imports: [
-    MongooseModule.forFeature([
-      { name: 'categories', schema: CategorySchema },
-    ]),
+    MongooseModule.forFeature([{ name: 'categories', schema: CategorySchema }]),
   ],
   providers: [CategoriesService],
   controllers: [CategoriesController],

--- a/src/models/categories/categories.module.ts
+++ b/src/models/categories/categories.module.ts
@@ -1,9 +1,16 @@
 import { Module } from '@nestjs/common';
 import { CategoriesService } from './categories.service';
 import { CategoriesController } from './categories.controller';
+import { MongooseModule } from '@nestjs/mongoose';
+import { CategorySchema } from './entities/category.entities';
 
 @Module({
+  imports: [
+    MongooseModule.forFeature([
+      { name: 'categories', schema: CategorySchema },
+    ]),
+  ],
   providers: [CategoriesService],
-  controllers: [CategoriesController]
+  controllers: [CategoriesController],
 })
 export class CategoriesModule {}

--- a/src/models/categories/categories.service.ts
+++ b/src/models/categories/categories.service.ts
@@ -1,12 +1,16 @@
 import { Injectable } from '@nestjs/common';
-import { ICategory } from "./interfaces/categories.interfaces";
+import { ICategory } from './interfaces/categories.interfaces';
+import { InjectModel } from '@nestjs/mongoose';
+import { Model } from 'mongoose';
+import { TCategorySchema } from './entities/category.entities';
 
 @Injectable()
 export class CategoriesService {
-  async findAllCategories(): Promise<ICategory> {
-    return {
-      name: '',
-      elementsCount: 0,
-    };
+  constructor(
+    @InjectModel('categories')
+    private readonly categoryModel: Model<TCategorySchema>,
+  ) {}
+  async findAllCategories(): Promise<ICategory[]> {
+    return this.categoryModel.find().exec();
   }
 }

--- a/src/models/categories/categories.service.ts
+++ b/src/models/categories/categories.service.ts
@@ -1,0 +1,12 @@
+import { Injectable } from '@nestjs/common';
+import { ICategory } from "./interfaces/categories.interfaces";
+
+@Injectable()
+export class CategoriesService {
+  async findAllCategories(): Promise<ICategory> {
+    return {
+      name: '',
+      elementsCount: 0,
+    };
+  }
+}

--- a/src/models/categories/entities/category.entities.ts
+++ b/src/models/categories/entities/category.entities.ts
@@ -1,0 +1,11 @@
+import { InferSchemaType, Schema, model, Model } from 'mongoose';
+import { ICategory } from '../interfaces/categories.interfaces';
+
+export const CategorySchema = new Schema<ICategory, Model<ICategory>>({
+  _id: String,
+  name: String,
+  elementsCount: Number,
+});
+export type TCategorySchema = InferSchemaType<typeof CategorySchema>;
+
+export const CategoryModel = model('categories', CategorySchema);

--- a/src/models/categories/interfaces/categories.interfaces.ts
+++ b/src/models/categories/interfaces/categories.interfaces.ts
@@ -1,0 +1,4 @@
+export interface ICategory {
+  name: string;
+  elementsCount: number;
+}

--- a/src/models/categories/interfaces/categories.interfaces.ts
+++ b/src/models/categories/interfaces/categories.interfaces.ts
@@ -1,4 +1,5 @@
 export interface ICategory {
+  _id: string;
   name: string;
   elementsCount: number;
 }

--- a/test/__mock__/categoryMock.model.ts
+++ b/test/__mock__/categoryMock.model.ts
@@ -1,0 +1,10 @@
+import { MockModel } from './mockDB.model';
+import { ICategory } from '../../src/models/categories/interfaces/categories.interfaces';
+
+export class CategoryMockModel extends MockModel<ICategory> {
+  protected entityStub = {
+    _id: 'string',
+    name: 'string',
+    elementsCount: 0,
+  };
+}

--- a/test/__mock__/mockDB.model.ts
+++ b/test/__mock__/mockDB.model.ts
@@ -5,6 +5,10 @@ export abstract class MockModel<T> {
     this.constructorSpy(createEntityData);
   }
 
+  getEntityStub() {
+    return this.entityStub;
+  }
+
   constructorSpy(_createEntityData: T): void {}
 
   findOne(): { exec: () => T } {
@@ -13,8 +17,12 @@ export abstract class MockModel<T> {
     };
   }
 
-  async find(): Promise<T[]> {
+  async exec(): Promise<T[]> {
     return [this.entityStub];
+  }
+
+  find() {
+    return this;
   }
 
   async getSlice(page, limit): Promise<T[]> {

--- a/test/__mock__/mockDB.model.ts
+++ b/test/__mock__/mockDB.model.ts
@@ -1,3 +1,4 @@
+/* eslint-disable */
 export abstract class MockModel<T> {
   protected abstract entityStub: T;
 

--- a/test/e2e/app.e2e-spec.ts
+++ b/test/e2e/app.e2e-spec.ts
@@ -57,4 +57,10 @@ describe('AppController (e2e)', () => {
         .expect(200);
     });
   });
+
+  describe('Categories Endpoints', () => {
+    it('/categories (GET)', () => {
+      return request(app.getHttpServer()).get('/categories').expect(200);
+    });
+  });
 });

--- a/test/models/categories/categories.controller.spec.ts
+++ b/test/models/categories/categories.controller.spec.ts
@@ -1,6 +1,8 @@
 import { Test, TestingModule } from '@nestjs/testing';
 import { CategoriesController } from '../../../src/models/categories/categories.controller';
 import { CategoriesService } from '../../../src/models/categories/categories.service';
+import { getModelToken } from '@nestjs/mongoose';
+import { CategoryMockModel } from '../../__mock__/categoryMock.model';
 
 describe('CategoriesController', () => {
   let controller: CategoriesController;
@@ -9,7 +11,13 @@ describe('CategoriesController', () => {
   beforeEach(async () => {
     const module: TestingModule = await Test.createTestingModule({
       controllers: [CategoriesController],
-      providers: [CategoriesService],
+      providers: [
+        CategoriesService,
+        {
+          provide: getModelToken('categories'),
+          useClass: CategoryMockModel,
+        },
+      ],
     }).compile();
 
     controller = module.get<CategoriesController>(CategoriesController);
@@ -22,10 +30,13 @@ describe('CategoriesController', () => {
 
   describe('getAllCategories', () => {
     it('should return an array of categories obtained by service function', async () => {
-      const expectedResult = {
-        name: 'catExample',
-        elementsCount: 10,
-      };
+      const expectedResult = [
+        {
+          _id: 'id',
+          name: 'catExample',
+          elementsCount: 10,
+        },
+      ];
       const spy = jest
         .spyOn(service, 'findAllCategories')
         .mockResolvedValue(expectedResult);

--- a/test/models/categories/categories.controller.spec.ts
+++ b/test/models/categories/categories.controller.spec.ts
@@ -1,0 +1,37 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { CategoriesController } from '../../../src/models/categories/categories.controller';
+import { CategoriesService } from '../../../src/models/categories/categories.service';
+
+describe('CategoriesController', () => {
+  let controller: CategoriesController;
+  let service: CategoriesService;
+
+  beforeEach(async () => {
+    const module: TestingModule = await Test.createTestingModule({
+      controllers: [CategoriesController],
+      providers: [CategoriesService],
+    }).compile();
+
+    controller = module.get<CategoriesController>(CategoriesController);
+    service = module.get<CategoriesService>(CategoriesService);
+  });
+
+  it('should be defined', () => {
+    expect(controller).toBeDefined();
+  });
+
+  describe('getAllCategories', () => {
+    it('should return an array of categories obtained by service function', async () => {
+      const expectedResult = {
+        name: 'catExample',
+        elementsCount: 10,
+      };
+      const spy = jest
+        .spyOn(service, 'findAllCategories')
+        .mockResolvedValue(expectedResult);
+      const result = await controller.getAllCategories();
+      expect(result).toEqual(expectedResult);
+      expect(spy).toBeCalled();
+    });
+  });
+});

--- a/test/models/categories/categories.service.spec.ts
+++ b/test/models/categories/categories.service.spec.ts
@@ -2,8 +2,6 @@ import { Test, TestingModule } from '@nestjs/testing';
 import { CategoriesService } from '../../../src/models/categories/categories.service';
 import { getModelToken } from '@nestjs/mongoose';
 import { CategoryMockModel } from '../../__mock__/categoryMock.model';
-import { Pagination } from '../../../src/common/decorators/paginationParams';
-import * as module from "module";
 
 describe('CategoriesService', () => {
   let service: CategoriesService;

--- a/test/models/categories/categories.service.spec.ts
+++ b/test/models/categories/categories.service.spec.ts
@@ -1,18 +1,45 @@
 import { Test, TestingModule } from '@nestjs/testing';
 import { CategoriesService } from '../../../src/models/categories/categories.service';
+import { getModelToken } from '@nestjs/mongoose';
+import { CategoryMockModel } from '../../__mock__/categoryMock.model';
+import { Pagination } from '../../../src/common/decorators/paginationParams';
+import * as module from "module";
 
 describe('CategoriesService', () => {
   let service: CategoriesService;
+  let model: CategoryMockModel;
 
   beforeEach(async () => {
     const module: TestingModule = await Test.createTestingModule({
-      providers: [CategoriesService],
+      providers: [
+        CategoriesService,
+        {
+          provide: getModelToken('categories'),
+          useClass: CategoryMockModel,
+        },
+      ],
     }).compile();
 
     service = module.get<CategoriesService>(CategoriesService);
+    model = module.get(getModelToken('categories'));
   });
 
   it('should be defined', () => {
     expect(service).toBeDefined();
+    expect(model).toBeDefined();
+  });
+
+  it('should call find to get all categories', async () => {
+    const spy = jest.spyOn(model, 'find');
+    await service.findAllCategories();
+
+    expect(spy).toBeCalled();
+  });
+
+  it('should return data found', async () => {
+    const expectedResult = [model.getEntityStub()];
+    const result = await service.findAllCategories();
+
+    expect(result).toEqual(expectedResult);
   });
 });

--- a/test/models/categories/categories.service.spec.ts
+++ b/test/models/categories/categories.service.spec.ts
@@ -1,0 +1,18 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { CategoriesService } from '../../../src/models/categories/categories.service';
+
+describe('CategoriesService', () => {
+  let service: CategoriesService;
+
+  beforeEach(async () => {
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [CategoriesService],
+    }).compile();
+
+    service = module.get<CategoriesService>(CategoriesService);
+  });
+
+  it('should be defined', () => {
+    expect(service).toBeDefined();
+  });
+});


### PR DESCRIPTION
## Description:
This pull request introduces a new API endpoint designed to retrieve the list of available categories within the FreshCart Market platform. Each category entry returned by the API includes essential details such as its name, count of products relative to that category.

## Motivation:
By providing direct access to comprehensive category information via a well-structured API, we empower the frontend to render categories listings swiftly and seamlessly.

## Changes Made:

- Implemented categories Get endpoint the backend API.
- Implemented categories controller and service.
- Created mongoose schema for categories.
- Integrated mongoose model in categories service.

## Testing:

- Conducted unit tests for products controller and service logic.
- Conducted e2e tests for products endpoint.